### PR TITLE
Update kernel version from 4.4.113 to 4.4.159

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+This is the BSP repository for the Samsung Artik board.
+======================================================
+
+It contains configuration files and recipes for all 
+the machines supported by Balena. 

--- a/recipes-kernel/linux/linux-yocto-artik53x.bb
+++ b/recipes-kernel/linux/linux-yocto-artik53x.bb
@@ -2,13 +2,13 @@ SUMMARY = "Samsung Artik 530 and Artik 530s 1G (a.k.a. Artik 533s) kernel"
 DESCRIPTION = "artik530 and artik533s machine kernel provided by Samsung"
 
 LINUX_VERSION_artik530 = "4.4.113"
-LINUX_VERSION_artik533s = "4.4.113"
+LINUX_VERSION_artik533s = "4.4.159"
 
 SRC_URI_artik530 = "git://github.com/SamsungARTIK/linux-artik.git;protocol=https;branch=A530-OS-18.05.00"
 SRCREV_artik530 = "release/A530s-OS-18.05.00"
 
-SRC_URI_artik533s = "git://github.com/SamsungARTIK/linux-artik.git;protocol=https;branch=A533s-OS-18.05.00"
-SRCREV_artik533s = "release/A533s-OS-18.05.00"
+SRC_URI_artik533s = "git://github.com/SamsungARTIK/linux-artik.git;protocol=https;branch=ARTIK-SW-18.10.00"
+SRCREV_artik533s = "75f01d3be5d04083a27a87aa9b3edd79a6495c95"
 
 require recipes-kernel/linux/linux-yocto.inc
 


### PR DESCRIPTION
Apart from the update itself, this is to fix a failure
to find WiFi networks after scanning.

Changelog-entry: Update kernel from 4.4.113 to 4.4.159
Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>